### PR TITLE
Fix: Bring `rocket` up to spec & fix `FromRequest` usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ rocket = { version = "0.5.0-rc.1", features = ["json"] }
 blockstack-core = {  git = "https://github.com/syvita/stacks" }
 r2d2 = "0.8.9"
 r2d2_redis = "0.14.0"
+anyhow = "1.0.52"

--- a/src/db/redis.rs
+++ b/src/db/redis.rs
@@ -36,7 +36,7 @@ pub struct Pool(pub r2d2::Pool<RedisConnectionManager>);
 impl<'r> request::FromRequest<'r> for Pool {
 	type Error = AnyhowError;
 	
-    async fn from_request(request: &'r request::Request<'_>) -> request::Outcome<RedisConnection, Self::Error> {
+    async fn from_request(request: &'r request::Request<'_>) -> request::Outcome<Pool, Self::Error> {
         match request.guard::<Pool>().await {
         	Success(pool) => Outcome::Success(pool),
 			Failure(error) => Outcome::Failure((http::Status::ServiceUnavailable, anyhow!(error.0))),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 #[macro_use] extern crate rocket;
 extern crate figment;
 extern crate num_cpus;
+#[macro_use] extern crate anyhow;
 
 #[cfg(test)] mod tests;
 


### PR DESCRIPTION
Looks like you were using Rocket 5.0.0 while trying to use it's 4.0.0 API docs, you can view the 5.0.0 docs [here](https://api.rocket.rs/v0.5-rc/rocket/).

`FromRequest` is async and can only return `Self`, so it can't get connection from the pool as was previously used (?).